### PR TITLE
Use http module's HTTP status code constants for readability

### DIFF
--- a/esa/esa.go
+++ b/esa/esa.go
@@ -53,7 +53,7 @@ func (c *Client) post(esaURL string, bodyType string, body io.Reader, v interfac
 
 	defer res.Body.Close()
 
-	if res.StatusCode != 201 {
+	if res.StatusCode != http.StatusCreated {
 		return nil, errors.New(http.StatusText(res.StatusCode))
 	}
 
@@ -78,7 +78,7 @@ func (c *Client) patch(esaURL string, bodyType string, body io.Reader, v interfa
 
 	defer res.Body.Close()
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return nil, errors.New(http.StatusText(res.StatusCode))
 	}
 
@@ -102,7 +102,7 @@ func (c *Client) delete(esaURL string) (resp *http.Response, err error) {
 
 	defer res.Body.Close()
 
-	if res.StatusCode != 204 {
+	if res.StatusCode != http.StatusNoContent {
 		return nil, errors.New(http.StatusText(res.StatusCode))
 	}
 
@@ -123,7 +123,7 @@ func (c *Client) get(esaURL string, query url.Values, v interface{}) (resp *http
 
 	defer res.Body.Close()
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return nil, errors.New(http.StatusText(res.StatusCode))
 	}
 

--- a/esa/test_helper.go
+++ b/esa/test_helper.go
@@ -18,15 +18,15 @@ func Stub(filename string, outRes interface{}) (*httptest.Server, *Client) {
 		var statusCode int
 		switch r.Method {
 		case "GET":
-			statusCode = 200
+			statusCode = http.StatusOK
 		case "POST":
-			statusCode = 201
+			statusCode = http.StatusCreated
 		case "PATCH":
-			statusCode = 200
+			statusCode = http.StatusOK
 		case "DELETE":
-			statusCode = 204
+			statusCode = http.StatusNoContent
 		default:
-			statusCode = 200
+			statusCode = http.StatusOK
 		}
 		w.WriteHeader(statusCode)
 		w.Write([]byte(stub))


### PR DESCRIPTION
`net/http` module provides HTTP status code constants :handbag:  : https://golang.org/src/net/http/status.go
It is useful to improve readability. :sparkles: 
