### PR TITLE
set query into body on GET HTTP Request

### DIFF
--- a/esa/comment.go
+++ b/esa/comment.go
@@ -3,7 +3,6 @@ package esa
 import (
 	"bytes"
 	"encoding/json"
-	"net/url"
 	"strconv"
 )
 
@@ -57,7 +56,7 @@ func (c *CommentService) GetComments(teamName string, postNumber int) (*Comments
 	postNumberStr := strconv.Itoa(postNumber)
 	commentURL := CommnetURL + "/" + teamName + "/posts" + "/" + postNumberStr + "/comments"
 
-	res, err := c.client.get(commentURL, url.Values{}, &commentsResponse)
+	res, err := c.client.get(commentURL, nil, &commentsResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +72,7 @@ func (c *CommentService) GetComment(teamName string, commentID int) (*CommentRes
 	commentIDStr := strconv.Itoa(commentID)
 	commentURL := CommnetURL + "/" + teamName + "/comments" + "/" + commentIDStr
 
-	res, err := c.client.get(commentURL, url.Values{}, &commentResponse)
+	res, err := c.client.get(commentURL, nil, &commentResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/esa/esa.go
+++ b/esa/esa.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 )
 
 const (
@@ -109,14 +108,11 @@ func (c *Client) delete(esaURL string) (resp *http.Response, err error) {
 	return res, nil
 }
 
-func (c *Client) get(esaURL string, query url.Values, v interface{}) (resp *http.Response, err error) {
-	path := c.createURL(esaURL)
-	queries := query.Encode()
-	if len(queries) != 0 {
-		path += "?" + queries
-	}
+func (c *Client) get(esaURL string, body io.Reader, v interface{}) (resp *http.Response, err error) {
+	req, _ := http.NewRequest("GET", c.createURL(esaURL), body)
+	req.Header.Add("Content-Type", "application/json")
 
-	res, err := c.client.Get(path)
+	res, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/esa/members.go
+++ b/esa/members.go
@@ -1,6 +1,5 @@
 package esa
 
-import "net/url"
 
 const (
 // MembersURL esa API のメンバーのベ-スURL
@@ -33,7 +32,7 @@ func (s *MembersService) Get(teamName string) (*MembersResponse, error) {
 	var membersRes MembersResponse
 
 	membersURL := MembersURL+ "/" + teamName + "/members"
-	res, err := s.client.get(membersURL, url.Values{}, &membersRes)
+	res, err := s.client.get(membersURL, nil, &membersRes)
 	if err != nil {
 		return nil, err
 	}

--- a/esa/post.go
+++ b/esa/post.go
@@ -99,13 +99,10 @@ func createSearchQuery(query url.Values) string {
 func (p *PostService) GetPosts(teamName string, query url.Values) (*PostsResponse, error) {
 	var postsRes PostsResponse
 	queries := createSearchQuery(query)
-
-	searchQuery := url.Values{}
-	searchQuery.Add("q", queries)
-	searchQuery.Encode()
+	buf, _ := json.Marshal(map[string]string{"q": queries})
 
 	postsURL := PostURL + "/" + teamName + "/posts"
-	res, err := p.client.get(postsURL, searchQuery, &postsRes)
+	res, err := p.client.get(postsURL, bytes.NewBuffer(buf), &postsRes)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +110,6 @@ func (p *PostService) GetPosts(teamName string, query url.Values) (*PostsRespons
 	defer res.Body.Close()
 
 	return &postsRes, nil
-
 }
 
 // GetPost チ-ム名と記事番号を指定して記事を取得する
@@ -123,7 +119,7 @@ func (p *PostService) GetPost(teamName string, postNumber int) (*PostResponse, e
 	postNumberStr := strconv.Itoa(postNumber)
 
 	postURL := PostURL + "/" + teamName + "/posts" + "/" + postNumberStr
-	res, err := p.client.get(postURL, url.Values{}, &postRes)
+	res, err := p.client.get(postURL, nil, &postRes)
 	if err != nil {
 		return nil, err
 	}

--- a/esa/stats.go
+++ b/esa/stats.go
@@ -1,6 +1,5 @@
 package esa
 
-import "net/url"
 
 const (
 	// StatsURL esa API の統計情報のベ-スURL
@@ -28,7 +27,7 @@ func (s *StatsService) Get(teamName string) (*StatsResponse, error) {
 	var statsRes StatsResponse
 
 	statsURL := StatsURL + "/" + teamName + "/stats"
-	res, err := s.client.get(statsURL, url.Values{}, &statsRes)
+	res, err := s.client.get(statsURL, nil, &statsRes)
 	if err != nil {
 		return nil, err
 	}

--- a/esa/team.go
+++ b/esa/team.go
@@ -1,7 +1,6 @@
 package esa
 
 import (
-	"net/url"
 )
 
 const (
@@ -34,7 +33,7 @@ type TeamsResponse struct {
 // GetTeams チ-ムを取得する
 func (t *TeamService) GetTeams() (*TeamsResponse, error) {
 	var teamsRes TeamsResponse
-	_, err := t.client.get(TeamURL, url.Values{}, &teamsRes)
+	_, err := t.client.get(TeamURL, nil, &teamsRes)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +45,7 @@ func (t *TeamService) GetTeams() (*TeamsResponse, error) {
 func (t *TeamService) GetTeam(teamName string) (*TeamResponse, error) {
 	var teamRes TeamResponse
 	teamURL := TeamURL + "/" + teamName
-	_, err := t.client.get(teamURL, url.Values{}, &teamRes)
+	_, err := t.client.get(teamURL, nil, &teamRes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
According to [the implement of official client](https://github.com/esaio/esa-ruby/blob/master/lib/esa/client.rb#L53), esa API seems to require to set query into not url parameter but body as json on GET Request.
Actually, current version failed to search posts using query like the following code.

``` go
func main() {
    apikey := os.Getenv("ESA_API_KEY")
    client := esa.NewClient(apikey)

    query := url.Values{}
    query.Add("starred", "true")

    res, err := client.Post.GetPosts("our team name", query)
    if err != nil {
        fmt.Println(err)
        return
    }

    fmt.Println(res)
}
```

```
~/dev/self/go-esa$ go build main.go
~/dev/self/go-esa$ ./main
Unauthorized
```

This patch version works fine in the above case.
But, I'm a beginner in golang. If this patch has any bad parts, I'd like you fix this trouble.
### 補足

英語に自信ないので補足しますと、どうも記事検索の条件はbodyで渡さないといけないみたいです。
この修正で、記事一覧の取得は条件付きでできるようにはなったと思いますが、それしかやってないので、他の部分への影響はよくわかってません。
また、自分Goを初めてやったので、作法やテストなどは全然です。
よろしくおねがいします。
