### PR TITLE
:+1 improve createSearchQuery for keyword only

### DIFF
--- a/esa/post.go
+++ b/esa/post.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -83,16 +84,18 @@ type SharedPost struct {
 }
 
 func createSearchQuery(query url.Values) string {
-	var queries string
+	var queries []string
 	for key, values := range query {
-		queries += key + ":"
 		for _, value := range values {
-			queries += value + " "
+			query := value
+			if key != "" {
+				query = key + ":" + query
+			}
+			queries = append(queries, query)
 		}
-		queries += "+"
 	}
 
-	return queries
+	return strings.Join(queries, " ")
 }
 
 // GetPosts チ-ム名とクエリを指定して記事を取得する
@@ -102,7 +105,6 @@ func (p *PostService) GetPosts(teamName string, query url.Values) (*PostsRespons
 
 	searchQuery := url.Values{}
 	searchQuery.Add("q", queries)
-	searchQuery.Encode()
 
 	postsURL := PostURL + "/" + teamName + "/posts"
 	res, err := p.client.get(postsURL, searchQuery, &postsRes)

--- a/esa/post_test.go
+++ b/esa/post_test.go
@@ -186,3 +186,51 @@ func TestDeleteSharing(t *testing.T) {
 		t.Errorf("error Request %s\n", err)
 	}
 }
+
+func Test_createSearchQuery(t *testing.T) {
+	type TestCase struct {
+		in  url.Values
+		out string
+	}
+
+	testCases := []TestCase{
+		{
+			in: url.Values{
+				"": []string{"esa"},
+			},
+			out: "esa",
+		},
+		{
+			in: url.Values{
+				"": []string{"esa", "docs"},
+			},
+			out: "esa docs",
+		},
+		{
+			in: url.Values{
+				"body": []string{"esa"},
+			},
+			out: "body:esa",
+		},
+		{
+			in: url.Values{
+				"body": []string{"esa", "docs"},
+			},
+			out: "body:esa body:docs",
+		},
+		{
+			in: url.Values{
+				"":     []string{"esa", "docs"},
+				"body": []string{"start"},
+			},
+			out: "esa docs body:start",
+		},
+	}
+
+	for _, ts := range testCases {
+		searchQuery := createSearchQuery(ts.in)
+		if ts.out != searchQuery {
+			t.Errorf("error searchQuery [%s] != [%s]", searchQuery, ts.out)
+		}
+	}
+}


### PR DESCRIPTION
- keywordのみを指定するqueryに対応しました
- 不要なスペースと `+` がついてしまうのを修正しました
- `url.Values{body: []string{"hoge", "fuga"}` のように `body:{keyword}` を複数指定するとき２つ目のkeywordに `body:` が付かないbugを修正しました
- 不要な `Encode()` 呼び出しを削除しました

### before execute test 

```
post_test.go:233: error searchQuery [:esa +] != [esa]
post_test.go:233: error searchQuery [:esa docs +] != [esa docs]
post_test.go:233: error searchQuery [body:esa +] != [body:esa]
post_test.go:233: error searchQuery [body:esa docs +] != [body:esa body:docs]
post_test.go:233: error searchQuery [:esa docs +body:start +] != [esa docs body:start]
```