### PR TITLE
update support other than search query into GetPosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,12 @@ client.Stats.Get("bar")
 client.Post.GetPosts("foo")
 // => GET /v1/teams/foo/posts
 
-searchQuery := url.Values{}
-searchQuery.Add("in", "help")
 query := url.Values{}
+query.Add("in", "help")
 query.Add("page", "1")
 query.Add("sort", "created")
 query.Add("order", "asc")
-client.Post.GetPosts("foo", searchQuery, query)
+client.Post.GetPosts("foo", query)
 // => GET /v1/teams/foo/posts?q=in%3Ahelp&page=1&sort=created&order=asc
 
 client.Post.GetPost("foo", 1)

--- a/README.md
+++ b/README.md
@@ -33,10 +33,14 @@ client.Stats.Get("bar")
 client.Post.GetPosts("foo")
 // => GET /v1/teams/foo/posts
 
+searchQuery := url.Values{}
+searchQuery.Add("in", "help")
 query := url.Values{}
-query.Add("in", "help")
-client.Post.GetPosts("foo", query)
-// => GET /v1/teams/foo/posts?q=in%3Ahelp
+query.Add("page", "1")
+query.Add("sort", "created")
+query.Add("order", "asc")
+client.Post.GetPosts("foo", searchQuery, query)
+// => GET /v1/teams/foo/posts?q=in%3Ahelp&page=1&sort=created&order=asc
 
 client.Post.GetPost("foo", 1)
 // => GET /v1/teams/foobar/posts/1

--- a/esa/post.go
+++ b/esa/post.go
@@ -98,16 +98,14 @@ func createSearchQuery(query url.Values) string {
 	return strings.Join(queries, " ")
 }
 
-// GetPosts チ-ム名とクエリを指定して記事を取得する
-func (p *PostService) GetPosts(teamName string, query url.Values) (*PostsResponse, error) {
+// GetPosts チ-ム名, 検索用クエリ, その他のクエリを指定して記事を取得する
+func (p *PostService) GetPosts(teamName string, searchQuery url.Values, queries url.Values) (*PostsResponse, error) {
 	var postsRes PostsResponse
-	queries := createSearchQuery(query)
-
-	searchQuery := url.Values{}
-	searchQuery.Add("q", queries)
+	q := createSearchQuery(searchQuery)
+	queries.Add("q", q)
 
 	postsURL := PostURL + "/" + teamName + "/posts"
-	res, err := p.client.get(postsURL, searchQuery, &postsRes)
+	res, err := p.client.get(postsURL, queries, &postsRes)
 	if err != nil {
 		return nil, err
 	}

--- a/esa/post.go
+++ b/esa/post.go
@@ -98,11 +98,26 @@ func createSearchQuery(query url.Values) string {
 	return strings.Join(queries, " ")
 }
 
-// GetPosts チ-ム名, 検索用クエリ, その他のクエリを指定して記事を取得する
-func (p *PostService) GetPosts(teamName string, searchQuery url.Values, queries url.Values) (*PostsResponse, error) {
+func createQuery(query url.Values) url.Values {
+	queries := url.Values{}
+	searchQuery := query
+
+	queryKey := []string{"page", "per_page", "q", "include", "sort", "order"}
+	for _, key := range queryKey {
+		if value := query.Get(key); value != "" {
+			queries.Add(key, value)
+			searchQuery.Del(key)
+		}
+	}
+
+	queries.Add("q", createSearchQuery(searchQuery))
+	return queries
+}
+
+// GetPosts チ-ム名とクエリを指定して記事を取得する
+func (p *PostService) GetPosts(teamName string, query url.Values) (*PostsResponse, error) {
 	var postsRes PostsResponse
-	q := createSearchQuery(searchQuery)
-	queries.Add("q", q)
+	queries := createQuery(query)
 
 	postsURL := PostURL + "/" + teamName + "/posts"
 	res, err := p.client.get(postsURL, queries, &postsRes)

--- a/esa/post_test.go
+++ b/esa/post_test.go
@@ -22,7 +22,7 @@ func TestPostGetPosts(t *testing.T) {
 	serve, client := Stub(testCase.in, &testCase.out)
 	defer serve.Close()
 
-	res, err := client.Post.GetPosts("docs", url.Values{}, url.Values{})
+	res, err := client.Post.GetPosts("docs", url.Values{})
 	if err != nil {
 		t.Errorf("error Request %s\n", err)
 	}

--- a/esa/post_test.go
+++ b/esa/post_test.go
@@ -22,7 +22,7 @@ func TestPostGetPosts(t *testing.T) {
 	serve, client := Stub(testCase.in, &testCase.out)
 	defer serve.Close()
 
-	res, err := client.Post.GetPosts("docs", url.Values{})
+	res, err := client.Post.GetPosts("docs", url.Values{}, url.Values{})
 	if err != nil {
 		t.Errorf("error Request %s\n", err)
 	}


### PR DESCRIPTION
## GetPostsにおいて検索クエリ以外のクエリに対応した

### 問題
GetPostsで指定するクエリは検索するクエリのみの対応となっていて`query.Add("page", "1")`のように他のクエリの指定をしても`page:1`のようなリクエストになってしまい正常な処理をしていなかった.

### 解決
クエリの追加処理を`query.Add("in", "help")`から`query.Add("q", "in:help")`にすることで他のすべてのクエリに対応可能であったが, createSearchQueryで専用に処理をしていたので検索クエリとそれ以外のクエリの2つをGetPostsで受け取ることで対応した.
ただ, createSearchQeuryを削除しクエリの追加をquery.Add(KEY, STRING)のように統一したほうが良いと思う.
