### PR TITLE
Fix indications of golint.

### DIFF
--- a/esa/comment.go
+++ b/esa/comment.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	// CommentURL esa API のコメントのベ-スURL
+	// CommnetURL esa API のコメントのベ-スURL
 	CommnetURL = "/v1/teams"
 )
 
@@ -51,7 +51,7 @@ type Comment struct {
 	User   string `json:"user"`
 }
 
-// GetTeamPostComments チ-ム名と記事番号を指定してコメントを取得する.
+// GetComments チ-ム名と記事番号を指定してコメントを取得する.
 func (c *CommentService) GetComments(teamName string, postNumber int) (*CommentsResponse, error) {
 	var commentsResponse CommentsResponse
 	postNumberStr := strconv.Itoa(postNumber)
@@ -67,7 +67,7 @@ func (c *CommentService) GetComments(teamName string, postNumber int) (*Comments
 	return &commentsResponse, nil
 }
 
-// GetTeamComment チ-ム名とコメントIDを取得してコメントを取得する.
+// GetComment チ-ム名とコメントIDを取得してコメントを取得する.
 func (c *CommentService) GetComment(teamName string, commentID int) (*CommentResponse, error) {
 	var commentResponse CommentResponse
 	commentIDStr := strconv.Itoa(commentID)
@@ -83,7 +83,7 @@ func (c *CommentService) GetComment(teamName string, commentID int) (*CommentRes
 	return &commentResponse, nil
 }
 
-// PostTeamPostComment チ-ム名と記事番号とコメントを指定してコメントを投稿する
+// Create チ-ム名と記事番号とコメントを指定してコメントを投稿する
 func (c *CommentService) Create(teamName string, postNumber int, comment Comment) (*CommentResponse, error) {
 	postNumberStr := strconv.Itoa(postNumber)
 	commentURL := CommnetURL + "/" + teamName + "/posts" + "/" + postNumberStr + "/comments"
@@ -107,7 +107,7 @@ func (c *CommentService) Create(teamName string, postNumber int, comment Comment
 	return &commentResponse, nil
 }
 
-// PatchTeamComment チ-ム名とコメントIDとコメントを指定してコメントを更新する
+// Update チ-ム名とコメントIDとコメントを指定してコメントを更新する
 func (c *CommentService) Update(teamName string, commentID int, comment Comment) (*CommentResponse, error) {
 	commentIDStr := strconv.Itoa(commentID)
 	commentURL := CommnetURL + "/" + teamName + "/comments" + "/" + commentIDStr
@@ -131,7 +131,7 @@ func (c *CommentService) Update(teamName string, commentID int, comment Comment)
 	return &commentResponse, nil
 }
 
-// DeleteTeamComment チ-ム名とコメントIDを指定してコメントを削除する
+// Delete チ-ム名とコメントIDを指定してコメントを削除する
 func (c *CommentService) Delete(teamName string, commentID int) error {
 	commentIDStr := strconv.Itoa(commentID)
 	commentURL := CommnetURL + "/" + teamName + "/comments" + "/" + commentIDStr

--- a/esa/members.go
+++ b/esa/members.go
@@ -3,7 +3,7 @@ package esa
 import "net/url"
 
 const (
-// MembersURL esa API のメンバーのベ-スURL
+	// MembersURL esa API のメンバーのベ-スURL
 	MembersURL = "/v1/teams"
 )
 
@@ -22,17 +22,17 @@ type Member struct {
 
 // MembersResponse メンバー情報のレスポンス
 type MembersResponse struct {
-	Members []Member `json:"members"`
+	Members    []Member    `json:"members"`
 	NextPage   interface{} `json:"next_page"`
 	PrevPage   interface{} `json:"prev_page"`
 	TotalCount int         `json:"total_count"`
 }
 
-// GetTeamMembers チ-ム名を指定してメンバー情報を取得する
+// Get チ-ム名を指定してメンバー情報を取得する
 func (s *MembersService) Get(teamName string) (*MembersResponse, error) {
 	var membersRes MembersResponse
 
-	membersURL := MembersURL+ "/" + teamName + "/members"
+	membersURL := MembersURL + "/" + teamName + "/members"
 	res, err := s.client.get(membersURL, url.Values{}, &membersRes)
 	if err != nil {
 		return nil, err

--- a/esa/stats.go
+++ b/esa/stats.go
@@ -23,7 +23,7 @@ type StatsResponse struct {
 	WeeklyActiveUsers  int `json:"weekly_active_users"`
 }
 
-// GetTeamStats チ-ム名を指定して統計情報を取得する
+// Get チ-ム名を指定して統計情報を取得する
 func (s *StatsService) Get(teamName string) (*StatsResponse, error) {
 	var statsRes StatsResponse
 

--- a/esa/team.go
+++ b/esa/team.go
@@ -23,7 +23,7 @@ type TeamResponse struct {
 	URL         string `json:"url"`
 }
 
-// TeamsRespons 複数チ-ムのレスポンス
+// TeamsResponse 複数チ-ムのレスポンス
 type TeamsResponse struct {
 	Teams      []TeamResponse `json:"teams"`
 	PrevPage   interface{}    `json:"prev_page"`


### PR DESCRIPTION
Fix indications of [golint](https://github.com/golang/lint).

```sh
micheam:go-esa$ golint ./...
esa/comment.go:11:2: comment on exported const CommnetURL should be of the form "CommnetURL ..."
esa/comment.go:54:1: comment on exported method CommentService.GetComments should be of the form "GetComments ..."
esa/comment.go:70:1: comment on exported method CommentService.GetComment should be of the form "GetComment ..."
esa/comment.go:86:1: comment on exported method CommentService.Create should be of the form "Create ..."
esa/comment.go:110:1: comment on exported method CommentService.Update should be of the form "Update ..."
esa/comment.go:134:1: comment on exported method CommentService.Delete should be of the form "Delete ..."
esa/members.go:31:1: comment on exported method MembersService.Get should be of the form "Get ..."
esa/stats.go:26:1: comment on exported method StatsService.Get should be of the form "Get ..."
esa/team.go:26:1: comment on exported type TeamsResponse should be of the form "TeamsResponse ..." (with optional leading article)
```